### PR TITLE
Add HEAD request handling

### DIFF
--- a/lib/kirei/routing/base.rb
+++ b/lib/kirei/routing/base.rb
@@ -91,6 +91,8 @@ module Kirei
           RackResponseType,
         )
 
+        response_body = [] if http_verb == Verb::HEAD
+
         after_hooks = collect_hooks(controller, :after_hooks)
         run_hooks(after_hooks)
 

--- a/lib/kirei/routing/router.rb
+++ b/lib/kirei/routing/router.rb
@@ -44,7 +44,14 @@ module Kirei
       end
       def get(verb, path)
         key = "#{verb.serialize} #{path}"
-        routes[key]
+        route = routes[key]
+
+        if route.nil? && verb == Verb::HEAD
+          key = "#{Verb::GET.serialize} #{path}"
+          route = routes[key]
+        end
+
+        route
       end
 
       sig { params(routes: T::Array[Route]).void }

--- a/spec/head_request_spec.rb
+++ b/spec/head_request_spec.rb
@@ -1,0 +1,36 @@
+# typed: false
+
+class DummyHeadController < Kirei::Controller
+  def index
+    render('ok', status: 200)
+  end
+end
+
+RSpec.describe 'HEAD request handling' do
+  before do
+    Kirei::Routing::Router.instance.routes.clear
+    route = Kirei::Routing::Route.new(
+      verb: Kirei::Routing::Verb::GET,
+      path: '/head',
+      controller: DummyHeadController,
+      action: 'index'
+    )
+    Kirei::Routing::Router.add_routes([route])
+  end
+
+  it 'returns empty body for HEAD requests' do
+    env = {
+      'REQUEST_METHOD' => 'HEAD',
+      'REQUEST_PATH' => '/head',
+      'QUERY_STRING' => '',
+      'rack.input' => StringIO.new(''),
+      'HTTP_HOST' => 'example.com',
+      'REMOTE_ADDR' => '127.0.0.1'
+    }
+
+    status, _headers, body = Kirei::Routing::Base.new.call(env)
+
+    expect(status).to eq(200)
+    expect(body).to eq([])
+  end
+end


### PR DESCRIPTION
## Summary
- allow Router to fall back to GET routes when HEAD route missing
- ensure Base returns empty body for HEAD requests
- test HEAD request behaviour

## Testing
- `bundle exec rake -T` *(fails: Bundler::GemNotFound)*