### PR TITLE
Fix typo in gemspec comment

### DIFF
--- a/kirei.gemspec
+++ b/kirei.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
     "kirei.gemspec",
     ".irbrc",
     "lib/**/*",
-    # do not include RBIs for gems, because users might use different verions
+    # do not include RBIs for gems, because users might use different versions
     "sorbet/rbi/dsl/**/*.rbi",
     "sorbet/rbi/shims/**/*.rbi",
     "LICENSE",


### PR DESCRIPTION
## Summary
- fix a spelling typo in `kirei.gemspec` comment

## Testing
- `bundle exec rspec` *(fails: bundler could not install gems due to network restrictions)*