### PR TITLE
Fix vector_column? when column is missing

### DIFF
--- a/lib/kirei/model/class_methods.rb
+++ b/lib/kirei/model/class_methods.rb
@@ -106,10 +106,12 @@ module Kirei
       #
       sig { params(column_name: String).returns(T::Boolean) }
       def vector_column?(column_name)
-        _col_name, col_info = T.let(
-          db.schema(table_name.to_sym).find { _1[0] == column_name.to_sym },
-          [Symbol, T::Hash[Symbol, T.untyped]],
+        col_info = T.let(
+          db.schema(table_name.to_sym).find { _1[0] == column_name.to_sym }&.last,
+          T.nilable(T::Hash[Symbol, T.untyped]),
         )
+        return false if col_info.nil?
+
         col_info.fetch(:db_type).match?(/vector\(\d+\)/)
       end
 

--- a/spec/vector_column_spec.rb
+++ b/spec/vector_column_spec.rb
@@ -1,0 +1,27 @@
+# typed: false
+require 'spec_helper'
+
+RSpec.describe Kirei::Model::ClassMethods do
+  describe '#vector_column?' do
+    let(:model_class) do
+      Class.new(T::Struct) do
+        include Kirei::Model
+        const :id, String
+      end
+    end
+
+    let(:db_double) { instance_double(Sequel::Database) }
+
+    before do
+      allow(model_class).to receive(:db).and_return(db_double)
+      allow(db_double).to receive(:schema).with(model_class.table_name.to_sym).and_return([
+        [:id, { db_type: 'text' }],
+        [:embedding, { db_type: 'vector(3)' }]
+      ])
+    end
+
+    it 'returns false for an unknown column' do
+      expect(model_class.vector_column?('unknown')).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- guard when a vector column is missing
- add spec for missing vector column

## Testing
- `RBENV_VERSION=3.3.8 bundle exec rspec` *(fails: bundler: command not found: rspec)*